### PR TITLE
feat: K8s individual health checks (/livez/postgres, ?verbose, ?exclude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,16 @@ reporter := httpserver.NewReporter(httpserver.Config{
 })
 ```
 
-Endpoints: `/livez`, `/readyz`, `/healthz`
+Endpoints: `/livez`, `/readyz`, `/healthz`, `/.well-known/health`
+
+Individual checks by name ([K8s convention](https://kubernetes.io/docs/reference/using-api/health-checks/#individual-health-checks)):
+
+```bash
+curl localhost:8181/livez/postgres    # [+]postgres ok (200)
+curl localhost:8181/readyz/redis      # [-]redis failed: timeout (503)
+curl localhost:8181/livez?verbose     # list all checks
+curl "localhost:8181/livez?verbose&exclude=redis"  # exclude a check
+```
 
 ### gRPC
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -586,6 +586,29 @@ startupProbe:
     health.WithStartupImpact(),
     health.WithCheckFrequency(health.CheckAtInterval, 2*time.Second, 0),
 )</code></pre>
+
+  <h3>Individual Health Checks</h3>
+  <p>Following the <a href="https://kubernetes.io/docs/reference/using-api/health-checks/#individual-health-checks">Kubernetes API health check convention</a>, you can query individual checks by name and get verbose output.</p>
+
+  <pre><code><span class="cmt"># Individual check by name</span>
+curl http://localhost:8181/livez/postgres
+<span class="cmt"># [+]postgres ok      (200)</span>
+
+curl http://localhost:8181/readyz/redis
+<span class="cmt"># [-]redis failed: connection refused    (503)</span>
+
+<span class="cmt"># Verbose: list all checks with status</span>
+curl http://localhost:8181/livez?verbose
+<span class="cmt"># [+]postgres ok</span>
+<span class="cmt"># [-]redis failed: connection refused</span>
+
+<span class="cmt"># Exclude a check from evaluation</span>
+curl "http://localhost:8181/livez?verbose&amp;exclude=redis"
+<span class="cmt"># [+]postgres ok      (200, redis excluded)</span></code></pre>
+
+  <div class="info-box">
+    <strong>Same pattern for all probes:</strong> <code>/livez/{name}</code>, <code>/readyz/{name}</code>, <code>/healthz/{name}</code>. Unknown check names return 404.
+  </div>
 </section>
 
 <!-- ARCHITECTURE INTERNALS -->

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -662,3 +662,164 @@ func TestManifestStatusDuringFailure(t *testing.T) {
 	}
 	t.Log("Manifest status recovered to 'pass'")
 }
+
+// ---------------------------------------------------------------------------
+// Test 9: Individual check by name returns correct status
+// ---------------------------------------------------------------------------
+
+func TestIndividualCheckByName(t *testing.T) {
+	ordersURL, cleanup := portForward(t, "orders-svc", 8182)
+	defer cleanup()
+
+	// /livez/postgres should return 200 with [+]postgres ok
+	code, body := httpGet(t, ordersURL+"/livez/postgres")
+	if code != 200 {
+		t.Fatalf("/livez/postgres: expected 200, got %d", code)
+	}
+	if !strings.Contains(string(body), "[+]postgres ok") {
+		t.Errorf("expected '[+]postgres ok', got %q", body)
+	}
+	t.Log("/livez/postgres: 200 [+]postgres ok")
+
+	// /readyz/redis should return 200 (redis is healthy)
+	code, body = httpGet(t, ordersURL+"/readyz/redis")
+	if code != 200 {
+		t.Fatalf("/readyz/redis: expected 200, got %d", code)
+	}
+	if !strings.Contains(string(body), "[+]redis ok") {
+		t.Errorf("expected '[+]redis ok', got %q", body)
+	}
+	t.Log("/readyz/redis: 200 [+]redis ok")
+
+	// /livez/nonexistent should return 404
+	code, _, err := httpGetSafe(ordersURL + "/livez/nonexistent")
+	if err != nil {
+		t.Fatalf("/livez/nonexistent: %v", err)
+	}
+	if code != 404 {
+		t.Errorf("/livez/nonexistent: expected 404, got %d", code)
+	}
+	t.Log("/livez/nonexistent: 404 (correct)")
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Verbose output lists all checks with status
+// ---------------------------------------------------------------------------
+
+func TestVerboseOutput(t *testing.T) {
+	ordersURL, cleanup := portForward(t, "orders-svc", 8182)
+	defer cleanup()
+
+	// /readyz?verbose should list all 3 checks
+	code, body, err := httpGetSafe(ordersURL + "/readyz?verbose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+
+	if code != 200 {
+		t.Fatalf("/readyz?verbose: expected 200 when all healthy, got %d\n%s", code, text)
+	}
+
+	// Should contain all 3 checks
+	for _, name := range []string{"postgres", "redis", "payments-api"} {
+		if !strings.Contains(text, "[+]"+name+" ok") {
+			t.Errorf("verbose output missing '[+]%s ok', got:\n%s", name, text)
+		}
+	}
+	t.Logf("Verbose output has all 3 checks:\n%s", text)
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Individual check shows failure during Redis outage
+// ---------------------------------------------------------------------------
+
+func TestIndividualCheckDuringFailure(t *testing.T) {
+	ordersURL, cleanup := portForward(t, "orders-svc", 8182)
+	defer cleanup()
+
+	// Kill Redis
+	t.Log("Scaling Redis to 0...")
+	ensureScale(t, "redis", 0)
+
+	// Wait for the redis individual check to go unhealthy
+	t.Log("Waiting for /readyz/redis to return 503...")
+	ok, lastCode := pollForStatus(ordersURL+"/readyz/redis", 503, 30*time.Second)
+	if !ok {
+		t.Fatalf("/readyz/redis did not go 503, last code: %d", lastCode)
+	}
+	t.Log("/readyz/redis: 503 (correct)")
+
+	// postgres individual check should still be 200
+	code, _, err := httpGetSafe(ordersURL + "/livez/postgres")
+	if err != nil {
+		t.Fatalf("/livez/postgres: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("/livez/postgres should still be 200 during Redis outage, got %d", code)
+	}
+	t.Log("/livez/postgres: still 200 (correct, Redis failure is isolated)")
+
+	// Restore Redis
+	t.Log("Restoring Redis...")
+	ensureScale(t, "redis", 1)
+
+	// Wait for recovery
+	ok, _ = pollForStatus(ordersURL+"/readyz/redis", 200, 30*time.Second)
+	if !ok {
+		t.Fatal("/readyz/redis did not recover")
+	}
+	t.Log("/readyz/redis: recovered to 200")
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Exclude parameter removes check from evaluation
+// ---------------------------------------------------------------------------
+
+func TestVerboseExclude(t *testing.T) {
+	ordersURL, cleanup := portForward(t, "orders-svc", 8182)
+	defer cleanup()
+
+	// Kill Redis
+	t.Log("Scaling Redis to 0...")
+	ensureScale(t, "redis", 0)
+
+	// Wait for aggregate readyz to fail
+	t.Log("Waiting for /readyz to return 503...")
+	ok, _ := pollForStatus(ordersURL+"/readyz", 503, 30*time.Second)
+	if !ok {
+		t.Fatal("/readyz did not go 503")
+	}
+
+	// /readyz?verbose&exclude=redis should return 200 (only postgres + payments, both healthy)
+	t.Log("Testing /readyz?verbose&exclude=redis...")
+	deadline := time.Now().Add(15 * time.Second)
+	passed := false
+	var lastBody string
+	for time.Now().Before(deadline) {
+		code, body, err := httpGetSafe(ordersURL + "/readyz?verbose&exclude=redis")
+		if err == nil {
+			lastBody = string(body)
+			if code == 200 {
+				passed = true
+				break
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !passed {
+		t.Fatalf("/readyz?verbose&exclude=redis: expected 200, got body:\n%s", lastBody)
+	}
+
+	// Verify redis is not in the output
+	if strings.Contains(lastBody, "redis") {
+		t.Errorf("excluded redis should not appear in verbose output:\n%s", lastBody)
+	}
+	t.Logf("Exclude works correctly:\n%s", lastBody)
+
+	// Restore Redis
+	t.Log("Restoring Redis...")
+	ensureScale(t, "redis", 1)
+	pollForStatus(ordersURL+"/readyz", 200, 30*time.Second)
+	t.Log("System recovered")
+}

--- a/reporter/httpserver/reporter.go
+++ b/reporter/httpserver/reporter.go
@@ -37,6 +37,9 @@ type Reporter struct {
 	logger      health.Logger
 	serviceName string
 	serviceVer  string
+	livePath    string
+	readyPath   string
+	startupPath string
 }
 
 // New creates an HTTP reporter with functional options.
@@ -60,10 +63,17 @@ func NewReporter(cfg Config) *Reporter {
 }
 
 func newFromConfig(cfg Config) *Reporter {
+	livePath := "/" + strings.TrimPrefix(cfg.LivenessRoute, "/")
+	readyPath := "/" + strings.TrimPrefix(cfg.ReadinessRoute, "/")
+	startupPath := "/" + strings.TrimPrefix(cfg.StartupRoute, "/")
+
 	reporter := Reporter{
 		hcCache:     mkCache(),
 		serviceName: cfg.ServiceName,
 		serviceVer:  cfg.ServiceVersion,
+		livePath:    livePath,
+		readyPath:   readyPath,
+		startupPath: startupPath,
 	}
 
 	reporter.logger = cfg.Logger
@@ -72,9 +82,15 @@ func newFromConfig(cfg Config) *Reporter {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/"+strings.TrimPrefix(cfg.LivenessRoute, "/"), reporter.reportLiveness)
-	mux.HandleFunc("/"+strings.TrimPrefix(cfg.ReadinessRoute, "/"), reporter.reportReadiness)
-	mux.HandleFunc("/"+strings.TrimPrefix(cfg.StartupRoute, "/"), reporter.reportStartup)
+	// exact path: aggregate probe status + JSON body
+	mux.HandleFunc(livePath, reporter.reportLiveness)
+	mux.HandleFunc(readyPath, reporter.reportReadiness)
+	mux.HandleFunc(startupPath, reporter.reportStartup)
+	// sub-path: individual check by name (e.g., /livez/postgres)
+	mux.HandleFunc(livePath+"/", reporter.reportIndividualCheck)
+	mux.HandleFunc(readyPath+"/", reporter.reportIndividualCheck)
+	mux.HandleFunc(startupPath+"/", reporter.reportIndividualCheck)
+	// discovery manifest
 	mux.HandleFunc("/.well-known/health", reporter.reportManifest)
 
 	var handler http.Handler
@@ -187,6 +203,11 @@ func (r *Reporter) reportLiveness(rw http.ResponseWriter, rq *http.Request) {
 		return
 	}
 
+	if _, ok := rq.URL.Query()["verbose"]; ok {
+		r.reportVerbose(rw, rq)
+		return
+	}
+
 	statusCode := LivenessAffirmativeResponseCode
 	if atomic.LoadUint32(&r.live) == 0 {
 		statusCode = LivenessNegativeResponseCode
@@ -201,6 +222,11 @@ func (r *Reporter) reportLiveness(rw http.ResponseWriter, rq *http.Request) {
 func (r *Reporter) reportReadiness(rw http.ResponseWriter, rq *http.Request) {
 	if atomic.LoadUint32(&r.running) == 0 {
 		r.reportNotRunning(rw, rq)
+		return
+	}
+
+	if _, ok := rq.URL.Query()["verbose"]; ok {
+		r.reportVerbose(rw, rq)
 		return
 	}
 
@@ -221,6 +247,11 @@ func (r *Reporter) reportStartup(rw http.ResponseWriter, rq *http.Request) {
 		return
 	}
 
+	if _, ok := rq.URL.Query()["verbose"]; ok {
+		r.reportVerbose(rw, rq)
+		return
+	}
+
 	statusCode := StartupAffirmativeResponseCode
 	if atomic.LoadUint32(&r.startup) == 0 {
 		statusCode = StartupNegativeResponseCode
@@ -230,6 +261,92 @@ func (r *Reporter) reportStartup(rw http.ResponseWriter, rq *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(statusCode)
 	_, _ = rw.Write(data)
+}
+
+// reportVerbose returns a K8s-style verbose health check listing.
+// Format: [+]name ok / [-]name failed: error
+// Supports ?exclude=name to omit specific checks.
+func (r *Reporter) reportVerbose(rw http.ResponseWriter, rq *http.Request) {
+	r.hcMx.RLock()
+	defer r.hcMx.RUnlock()
+
+	excludes := make(map[string]bool)
+	for _, name := range rq.URL.Query()["exclude"] {
+		excludes[name] = true
+	}
+
+	allOK := true
+	var buf strings.Builder
+	for name, hc := range r.hcs {
+		if excludes[name] {
+			continue
+		}
+		if hc.Status == health.StatusUnhealthy {
+			allOK = false
+			errMsg := "check failed"
+			if hc.Error != nil {
+				errMsg = hc.Error.Error()
+			}
+			fmt.Fprintf(&buf, "[-]%s failed: %s\n", name, errMsg)
+		} else {
+			fmt.Fprintf(&buf, "[+]%s ok\n", name)
+		}
+	}
+
+	if allOK {
+		rw.WriteHeader(http.StatusOK)
+	} else {
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}
+	rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = rw.Write([]byte(buf.String()))
+}
+
+// reportIndividualCheck handles /livez/<name>, /readyz/<name>, /healthz/<name>.
+// Returns 200 if the named check is healthy/degraded, 503 if unhealthy, 404 if not found.
+func (r *Reporter) reportIndividualCheck(rw http.ResponseWriter, rq *http.Request) {
+	if atomic.LoadUint32(&r.running) == 0 {
+		r.reportNotRunning(rw, rq)
+		return
+	}
+
+	// extract check name from path: /livez/postgres → postgres
+	path := rq.URL.Path
+	var checkName string
+	for _, prefix := range []string{r.livePath, r.readyPath, r.startupPath} {
+		trimmed := strings.TrimPrefix(path, prefix+"/")
+		if trimmed != path {
+			checkName = trimmed
+			break
+		}
+	}
+
+	if checkName == "" {
+		http.NotFound(rw, rq)
+		return
+	}
+
+	r.hcMx.RLock()
+	hc, ok := r.hcs[checkName]
+	r.hcMx.RUnlock()
+
+	if !ok {
+		http.NotFound(rw, rq)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if hc.Status == health.StatusUnhealthy {
+		rw.WriteHeader(http.StatusServiceUnavailable)
+		errMsg := "check failed"
+		if hc.Error != nil {
+			errMsg = hc.Error.Error()
+		}
+		fmt.Fprintf(rw, "[-]%s failed: %s\n", checkName, errMsg)
+	} else {
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprintf(rw, "[+]%s ok\n", checkName)
+	}
 }
 
 // reportManifest serves the /.well-known/health discovery manifest.

--- a/reporter/httpserver/reporter_test.go
+++ b/reporter/httpserver/reporter_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -458,5 +459,159 @@ func expectStatus(t *testing.T, actual, expected int) {
 func evalHealthCheckMap(t *testing.T, m map[string]checkJSON, f func(map[string]checkJSON) error) {
 	if err := f(m); err != nil {
 		t.Fatalf("health check eval failed: %v", err)
+	}
+}
+
+func TestIndividualCheck(t *testing.T) {
+	reporter := httpserver.NewReporter(httpserver.Config{
+		Addr:           "0.0.0.0",
+		Port:           8281,
+		LivenessRoute:  "/livez",
+		ReadinessRoute: "/readyz",
+		StartupRoute:   "/healthz",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		defer cancel()
+		reporter.Stop(ctx)
+	})
+
+	if err := reporter.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reporter.SetLiveness(ctx, true)
+	reporter.SetReadiness(ctx, true)
+
+	reporter.UpdateHealthChecks(ctx, map[string]*health.CheckResult{
+		"postgres": {Name: "postgres", Status: health.StatusHealthy},
+		"redis":    {Name: "redis", Status: health.StatusUnhealthy, Error: errors.New("connection refused")},
+	})
+
+	client := http.Client{Timeout: time.Second}
+
+	// individual healthy check
+	{
+		uri := "http://0.0.0.0:8281/livez/postgres"
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != 200 {
+			t.Errorf("/livez/postgres: expected 200, got %d", resp.StatusCode)
+		}
+		if !strings.Contains(string(body), "[+]postgres ok") {
+			t.Errorf("expected '[+]postgres ok', got %q", body)
+		}
+	}
+
+	// individual unhealthy check
+	{
+		uri := "http://0.0.0.0:8281/readyz/redis"
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != 503 {
+			t.Errorf("/readyz/redis: expected 503, got %d", resp.StatusCode)
+		}
+		if !strings.Contains(string(body), "[-]redis failed") {
+			t.Errorf("expected '[-]redis failed', got %q", body)
+		}
+	}
+
+	// individual check not found
+	{
+		uri := "http://0.0.0.0:8281/livez/nonexistent"
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 404 {
+			t.Errorf("/livez/nonexistent: expected 404, got %d", resp.StatusCode)
+		}
+	}
+}
+
+func TestVerbose(t *testing.T) {
+	reporter := httpserver.NewReporter(httpserver.Config{
+		Addr:           "0.0.0.0",
+		Port:           8282,
+		LivenessRoute:  "/livez",
+		ReadinessRoute: "/readyz",
+		StartupRoute:   "/healthz",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		defer cancel()
+		reporter.Stop(ctx)
+	})
+
+	if err := reporter.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reporter.SetLiveness(ctx, true)
+	reporter.UpdateHealthChecks(ctx, map[string]*health.CheckResult{
+		"postgres": {Name: "postgres", Status: health.StatusHealthy},
+		"redis":    {Name: "redis", Status: health.StatusUnhealthy, Error: errors.New("timeout")},
+	})
+
+	client := http.Client{Timeout: time.Second}
+
+	// verbose lists all checks
+	{
+		uri := "http://0.0.0.0:8282/livez?verbose"
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		text := string(body)
+
+		if resp.StatusCode != 503 {
+			t.Errorf("verbose with failing check: expected 503, got %d", resp.StatusCode)
+		}
+		if !strings.Contains(text, "[+]postgres ok") {
+			t.Errorf("expected postgres ok in verbose, got %q", text)
+		}
+		if !strings.Contains(text, "[-]redis failed") {
+			t.Errorf("expected redis failed in verbose, got %q", text)
+		}
+	}
+
+	// verbose with exclude
+	{
+		uri := "http://0.0.0.0:8282/livez?verbose&exclude=redis"
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		text := string(body)
+
+		if resp.StatusCode != 200 {
+			t.Errorf("verbose excluding failing check: expected 200, got %d", resp.StatusCode)
+		}
+		if strings.Contains(text, "redis") {
+			t.Errorf("excluded redis should not appear in output, got %q", text)
+		}
+		if !strings.Contains(text, "[+]postgres ok") {
+			t.Errorf("expected postgres in output, got %q", text)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Implements the [Kubernetes API health check convention](https://kubernetes.io/docs/reference/using-api/health-checks/#individual-health-checks) for per-check querying, verbose output, and check exclusion.

**Individual checks by name:**
- `GET /livez/postgres` → `200` with `[+]postgres ok`
- `GET /readyz/redis` → `503` with `[-]redis failed: connection refused`
- `GET /livez/nonexistent` → `404`

**Verbose output:**
- `GET /livez?verbose` → lists all checks: `[+]name ok` / `[-]name failed: error`
- Returns 200 if all checks pass, 503 if any fail

**Exclude parameter:**
- `GET /livez?verbose&exclude=redis` → evaluates all checks except redis
- Useful for debugging: "is everything except X healthy?"

Same pattern works for `/readyz` and `/healthz`.

~70 lines of new code in `reporter/httpserver/reporter.go`. No new deps.

## Test Coverage
- `TestIndividualCheck`: healthy (200), unhealthy (503), not found (404)
- `TestVerbose`: verbose with failing check (503), verbose with exclude (200)

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race ./...` all pass
- [x] README and docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)