### PR TITLE
fix: add permissions block to GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     name: test


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `test.yaml` and `e2e.yaml` workflows
- Resolves code scanning alerts #1 and #2 (missing workflow permissions)

## Test plan
- [x] Verify CI workflows still pass with restricted permissions
- [ ] Verify code scanning alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)