### PR TITLE
ci: add Codecov coverage upload to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,4 +19,8 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - run: go vet ./...
-      - run: go test -race -count=1 ./...
+      - run: go test -race -count=1 -coverprofile=coverage.txt ./...
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `-coverprofile=coverage.txt` to the test command
- Add Codecov upload step using `codecov/codecov-action@v5`

## Test plan
- [ ] Verify `CODECOV_TOKEN` secret is configured in repo settings
- [ ] Confirm coverage report uploads after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)