### PR TITLE
test: increase code coverage from 67% to 82%

### DIFF
--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,129 @@
+package health_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/schigh/health/v2"
+)
+
+func TestStatus_String(t *testing.T) {
+	tests := []struct {
+		status health.Status
+		want   string
+	}{
+		{health.StatusHealthy, "healthy"},
+		{health.StatusDegraded, "degraded"},
+		{health.StatusUnhealthy, "unhealthy"},
+		{health.Status(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("Status(%d).String() = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestCheckerFunc(t *testing.T) {
+	called := false
+	cf := health.CheckerFunc(func(_ context.Context) *health.CheckResult {
+		called = true
+		return &health.CheckResult{Name: "fn", Status: health.StatusHealthy}
+	})
+
+	result := cf.Check(context.Background())
+	if !called {
+		t.Fatal("expected CheckerFunc to be called")
+	}
+	if result.Name != "fn" {
+		t.Errorf("expected name 'fn', got %q", result.Name)
+	}
+}
+
+func TestWithCheckFrequency(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithCheckFrequency(health.CheckAtInterval, 5*time.Second, 2*time.Second)(&opts)
+
+	if opts.Frequency != health.CheckAtInterval {
+		t.Errorf("expected CheckAtInterval, got %v", opts.Frequency)
+	}
+	if opts.Interval != 5*time.Second {
+		t.Errorf("expected 5s interval, got %v", opts.Interval)
+	}
+	if opts.Delay != 2*time.Second {
+		t.Errorf("expected 2s delay, got %v", opts.Delay)
+	}
+}
+
+func TestWithLivenessImpact(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithLivenessImpact()(&opts)
+	if !opts.AffectsLiveness {
+		t.Error("expected AffectsLiveness to be true")
+	}
+}
+
+func TestWithReadinessImpact(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithReadinessImpact()(&opts)
+	if !opts.AffectsReadiness {
+		t.Error("expected AffectsReadiness to be true")
+	}
+}
+
+func TestWithStartupImpact(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithStartupImpact()(&opts)
+	if !opts.AffectsStartup {
+		t.Error("expected AffectsStartup to be true")
+	}
+}
+
+func TestWithGroup(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithGroup("database")(&opts)
+	if opts.Group != "database" {
+		t.Errorf("expected group 'database', got %q", opts.Group)
+	}
+}
+
+func TestWithComponentType(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithComponentType("datastore")(&opts)
+	if opts.ComponentType != "datastore" {
+		t.Errorf("expected component type 'datastore', got %q", opts.ComponentType)
+	}
+}
+
+func TestWithDependsOn(t *testing.T) {
+	var opts health.AddCheckOptions
+	health.WithDependsOn("http://svc-a/healthz", "http://svc-b/healthz")(&opts)
+	if len(opts.DependsOn) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(opts.DependsOn))
+	}
+	if opts.DependsOn[0] != "http://svc-a/healthz" {
+		t.Errorf("expected first dep 'http://svc-a/healthz', got %q", opts.DependsOn[0])
+	}
+}
+
+func TestDefaultLogger(t *testing.T) {
+	l := health.DefaultLogger()
+	if l == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	// should not panic
+	l.Debug("test")
+	l.Info("test")
+	l.Warn("test")
+	l.Error("test")
+}
+
+func TestNoOpLogger(t *testing.T) {
+	l := health.NoOpLogger{}
+	// should not panic
+	l.Debug("test")
+	l.Info("test")
+	l.Warn("test")
+	l.Error("test")
+}

--- a/reporter/httpserver/config_test.go
+++ b/reporter/httpserver/config_test.go
@@ -1,0 +1,94 @@
+package httpserver
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/schigh/health/v2"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.Addr != "0.0.0.0" {
+		t.Errorf("expected addr '0.0.0.0', got %q", cfg.Addr)
+	}
+	if cfg.Port != 8181 {
+		t.Errorf("expected port 8181, got %d", cfg.Port)
+	}
+	if cfg.LivenessRoute != "/livez" {
+		t.Errorf("expected liveness route '/livez', got %q", cfg.LivenessRoute)
+	}
+	if cfg.ReadinessRoute != "/readyz" {
+		t.Errorf("expected readiness route '/readyz', got %q", cfg.ReadinessRoute)
+	}
+	if cfg.StartupRoute != "/healthz" {
+		t.Errorf("expected startup route '/healthz', got %q", cfg.StartupRoute)
+	}
+}
+
+func TestOptions(t *testing.T) {
+	logger := health.NoOpLogger{}
+	mw := func(next http.Handler) http.Handler { return next }
+
+	opts := []Option{
+		WithAddr("127.0.0.1"),
+		WithPort(9090),
+		WithLivenessRoute("/live"),
+		WithReadinessRoute("/ready"),
+		WithStartupRoute("/startup"),
+		WithLogger(logger),
+		WithMiddleware(mw),
+		WithServiceName("test-svc"),
+		WithServiceVersion("1.0.0"),
+	}
+
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	if cfg.Addr != "127.0.0.1" {
+		t.Errorf("expected addr '127.0.0.1', got %q", cfg.Addr)
+	}
+	if cfg.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", cfg.Port)
+	}
+	if cfg.LivenessRoute != "/live" {
+		t.Errorf("expected liveness route '/live', got %q", cfg.LivenessRoute)
+	}
+	if cfg.ReadinessRoute != "/ready" {
+		t.Errorf("expected readiness route '/ready', got %q", cfg.ReadinessRoute)
+	}
+	if cfg.StartupRoute != "/startup" {
+		t.Errorf("expected startup route '/startup', got %q", cfg.StartupRoute)
+	}
+	if cfg.ServiceName != "test-svc" {
+		t.Errorf("expected service name 'test-svc', got %q", cfg.ServiceName)
+	}
+	if cfg.ServiceVersion != "1.0.0" {
+		t.Errorf("expected service version '1.0.0', got %q", cfg.ServiceVersion)
+	}
+	if len(cfg.Middleware) != 1 {
+		t.Errorf("expected 1 middleware, got %d", len(cfg.Middleware))
+	}
+}
+
+func TestNew(t *testing.T) {
+	r := New(WithPort(18383), WithServiceName("svc"), WithServiceVersion("v1"))
+	if r == nil {
+		t.Fatal("expected non-nil reporter")
+	}
+	if r.serviceName != "svc" {
+		t.Errorf("expected service name 'svc', got %q", r.serviceName)
+	}
+	if r.serviceVer != "v1" {
+		t.Errorf("expected service version 'v1', got %q", r.serviceVer)
+	}
+}
+
+func TestBasicAuth(t *testing.T) {
+	mw := BasicAuth("user", "pass")
+	if mw == nil {
+		t.Fatal("expected non-nil middleware")
+	}
+}

--- a/reporter/stdout/reporter_test.go
+++ b/reporter/stdout/reporter_test.go
@@ -1,0 +1,102 @@
+package stdout
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/schigh/health/v2"
+)
+
+func TestReporter_RunStop(t *testing.T) {
+	r := &Reporter{}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("unexpected error from Stop: %v", err)
+	}
+}
+
+func TestReporter_SetLiveness(t *testing.T) {
+	r := &Reporter{}
+	r.SetLiveness(context.Background(), true)
+	if r.live != 1 {
+		t.Error("expected live to be 1")
+	}
+	r.SetLiveness(context.Background(), false)
+	if r.live != 0 {
+		t.Error("expected live to be 0")
+	}
+}
+
+func TestReporter_SetReadiness(t *testing.T) {
+	r := &Reporter{}
+	r.SetReadiness(context.Background(), true)
+	if r.ready != 1 {
+		t.Error("expected ready to be 1")
+	}
+	r.SetReadiness(context.Background(), false)
+	if r.ready != 0 {
+		t.Error("expected ready to be 0")
+	}
+}
+
+func TestReporter_SetStartup(t *testing.T) {
+	r := &Reporter{}
+	r.SetStartup(context.Background(), true)
+	if r.startup != 1 {
+		t.Error("expected startup to be 1")
+	}
+	r.SetStartup(context.Background(), false)
+	if r.startup != 0 {
+		t.Error("expected startup to be 0")
+	}
+}
+
+func TestReporter_UpdateHealthChecks(t *testing.T) {
+	// Capture output via a temp file since w is *os.File
+	tmp, err := os.CreateTemp("", "stdout-reporter-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	origW := w
+	w = tmp
+	defer func() { w = origW }()
+
+	r := &Reporter{}
+	r.SetLiveness(context.Background(), true)
+	r.SetReadiness(context.Background(), false)
+	r.SetStartup(context.Background(), true)
+
+	r.UpdateHealthChecks(context.Background(), map[string]*health.CheckResult{
+		"db": {
+			Name:             "db",
+			Status:           health.StatusHealthy,
+			AffectsLiveness:  true,
+			AffectsReadiness: false,
+		},
+	})
+
+	// Read back what was written
+	tmp.Sync()
+	data, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(data)
+
+	if !strings.Contains(output, "yes") {
+		t.Error("expected 'yes' for live/startup in output")
+	}
+	if !strings.Contains(output, "db") {
+		t.Error("expected check name 'db' in output")
+	}
+	if !strings.Contains(output, "healthy") {
+		t.Error("expected 'healthy' status in output")
+	}
+}

--- a/reporter/test/reporter_test.go
+++ b/reporter/test/reporter_test.go
@@ -1,0 +1,174 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/schigh/health/v2"
+)
+
+func TestReporter_RunStop(t *testing.T) {
+	r := &Reporter{}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+	rpt := r.Report()
+	if !rpt.IsRunning {
+		t.Error("expected reporter to be running")
+	}
+	if rpt.NumRunningStateChanges != 1 {
+		t.Errorf("expected 1 running state change, got %d", rpt.NumRunningStateChanges)
+	}
+
+	if err := r.Stop(context.Background()); err != nil {
+		t.Fatalf("unexpected error from Stop: %v", err)
+	}
+	rpt = r.Report()
+	if rpt.IsRunning {
+		t.Error("expected reporter to not be running")
+	}
+	if rpt.NumRunningStateChanges != 2 {
+		t.Errorf("expected 2 running state changes, got %d", rpt.NumRunningStateChanges)
+	}
+}
+
+func TestReporter_SetLiveness(t *testing.T) {
+	r := &Reporter{}
+	r.SetLiveness(context.Background(), true)
+	rpt := r.Report()
+	if !rpt.IsLive {
+		t.Error("expected live")
+	}
+	if rpt.NumLivenessSetTrue != 1 {
+		t.Errorf("expected 1 liveness set true, got %d", rpt.NumLivenessSetTrue)
+	}
+
+	r.SetLiveness(context.Background(), false)
+	rpt = r.Report()
+	if rpt.IsLive {
+		t.Error("expected not live")
+	}
+	if rpt.NumLivenessSetFalse != 1 {
+		t.Errorf("expected 1 liveness set false, got %d", rpt.NumLivenessSetFalse)
+	}
+	if rpt.NumLivenessStateChanges != 2 {
+		t.Errorf("expected 2 liveness state changes, got %d", rpt.NumLivenessStateChanges)
+	}
+}
+
+func TestReporter_SetReadiness(t *testing.T) {
+	r := &Reporter{}
+	r.SetReadiness(context.Background(), true)
+	rpt := r.Report()
+	if !rpt.IsReady {
+		t.Error("expected ready")
+	}
+	if rpt.NumReadinessSetTrue != 1 {
+		t.Errorf("expected 1 readiness set true, got %d", rpt.NumReadinessSetTrue)
+	}
+
+	r.SetReadiness(context.Background(), false)
+	rpt = r.Report()
+	if rpt.IsReady {
+		t.Error("expected not ready")
+	}
+	if rpt.NumReadinessSetFalse != 1 {
+		t.Errorf("expected 1 readiness set false, got %d", rpt.NumReadinessSetFalse)
+	}
+}
+
+func TestReporter_SetStartup(t *testing.T) {
+	r := &Reporter{}
+	r.SetStartup(context.Background(), true)
+	rpt := r.Report()
+	if !rpt.IsStartup {
+		t.Error("expected startup")
+	}
+	if rpt.NumStartupSetTrue != 1 {
+		t.Errorf("expected 1 startup set true, got %d", rpt.NumStartupSetTrue)
+	}
+
+	r.SetStartup(context.Background(), false)
+	rpt = r.Report()
+	if rpt.IsStartup {
+		t.Error("expected not startup")
+	}
+	if rpt.NumStartupSetFalse != 1 {
+		t.Errorf("expected 1 startup set false, got %d", rpt.NumStartupSetFalse)
+	}
+}
+
+func TestReporter_UpdateHealthChecks(t *testing.T) {
+	r := &Reporter{}
+	r.UpdateHealthChecks(context.Background(), map[string]*health.CheckResult{
+		"db": {Name: "db", Status: health.StatusHealthy},
+	})
+	r.UpdateHealthChecks(context.Background(), map[string]*health.CheckResult{
+		"cache": {Name: "cache", Status: health.StatusUnhealthy},
+	})
+
+	rpt := r.Report()
+	if rpt.NumHealthCheckUpdates != 2 {
+		t.Errorf("expected 2 health check updates, got %d", rpt.NumHealthCheckUpdates)
+	}
+	if len(rpt.HealthChecks) != 2 {
+		t.Errorf("expected 2 health checks, got %d", len(rpt.HealthChecks))
+	}
+	if rpt.HealthChecks["db"].Status != health.StatusHealthy {
+		t.Error("expected db to be healthy")
+	}
+	if rpt.HealthChecks["cache"].Status != health.StatusUnhealthy {
+		t.Error("expected cache to be unhealthy")
+	}
+}
+
+func TestFromReporter_Valid(t *testing.T) {
+	r := &Reporter{}
+	got, ok := FromReporter(r)
+	if !ok {
+		t.Fatal("expected ok to be true")
+	}
+	if got != r {
+		t.Error("expected same pointer")
+	}
+}
+
+func TestFromReporter_Invalid(t *testing.T) {
+	_, ok := FromReporter(nil)
+	if ok {
+		t.Error("expected ok to be false for nil")
+	}
+}
+
+func TestReport_MarshalJSON(t *testing.T) {
+	r := &Reporter{}
+	r.Run(context.Background())
+	r.SetLiveness(context.Background(), true)
+	r.SetReadiness(context.Background(), true)
+	r.SetStartup(context.Background(), true)
+	r.UpdateHealthChecks(context.Background(), map[string]*health.CheckResult{
+		"db": {Name: "db", Status: health.StatusHealthy},
+	})
+
+	rpt := r.Report()
+	data, err := json.Marshal(rpt)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if parsed["isRunning"] != true {
+		t.Error("expected isRunning=true in JSON")
+	}
+	if parsed["isLive"] != true {
+		t.Error("expected isLive=true in JSON")
+	}
+	hcs, ok := parsed["healthChecks"].(map[string]any)
+	if !ok || len(hcs) != 1 {
+		t.Error("expected 1 health check in JSON")
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for root package (Status.String, functional options, CheckerFunc, loggers) — 39.5% → 97.4%
- Add unit tests for `reporter/stdout` — 0% → 96.2%
- Add unit tests for `reporter/test` — 0% → 100%
- Add unit tests for `reporter/httpserver` config/options — 64.3% → 74.3%
- **Total coverage: 67.4% → 82.3%**

## Test plan
- [x] `go test ./...` — all tests pass
- [x] Coverage verified at 82.3% via `go test -coverprofile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)